### PR TITLE
Handle ref type elements in xsd schema

### DIFF
--- a/src/CodeSuggester.ts
+++ b/src/CodeSuggester.ts
@@ -37,7 +37,7 @@ export default class CodeSuggester {
     ): ICompletion[] =>
         elements.map(
             (element: DocumentNode, index: number): ICompletion => {
-                const elementName = this.parseElementName(element.name, namespace)
+                const elementName = element.name ? this.parseElementName(this.parseDetail(element.name), namespace) : this.parseElementName(this.parseDetail(element.ref), namespace)
                 return {
                     label: elementName,
                     kind: withoutTag


### PR DESCRIPTION
Handle ref type element declaration in schema.
eg: the `section-number` is a ref type which is defined in some other place in the schema
```
<xs:complexType name="section-type">
        <xs:choice maxOccurs="unbounded">
            <xs:element minOccurs="0" ref="section-number"/>
            <xs:sequence minOccurs="0">
                <xs:element ref="section-heading"/>
                <xs:element minOccurs="0" ref="section-short-heading"/>
            </xs:sequence>
```