### PR TITLE
Get ref type elements and element attributes from attributeGroups

### DIFF
--- a/src/CodeSuggester.ts
+++ b/src/CodeSuggester.ts
@@ -37,7 +37,7 @@ export default class CodeSuggester {
     ): ICompletion[] =>
         elements.map(
             (element: DocumentNode, index: number): ICompletion => {
-                const elementName = this.parseElementName(element.name, namespace)
+                const elementName = element.name ? this.parseElementName(this.parseDetail(element.name), namespace) : this.parseElementName(this.parseDetail(element.ref), namespace)
                 return {
                     label: elementName,
                     kind: withoutTag

--- a/src/CodeSuggester.ts
+++ b/src/CodeSuggester.ts
@@ -37,7 +37,10 @@ export default class CodeSuggester {
     ): ICompletion[] =>
         elements.map(
             (element: DocumentNode, index: number): ICompletion => {
-                const elementName = element.name ? this.parseElementName(this.parseDetail(element.name), namespace) : this.parseElementName(this.parseDetail(element.ref), namespace)
+                let elementName = element.ref ? element.ref : element.name
+                if(elementName){
+                    elementName = this.parseElementName(elementName, namespace)
+                }
                 return {
                     label: elementName,
                     kind: withoutTag
@@ -68,15 +71,18 @@ export default class CodeSuggester {
 
     private parseAttributes = (attributes: DocumentNode[], incomplete: boolean): ICompletion[] =>
         attributes.map(
-            (attribute: DocumentNode): ICompletion => ({
-                label: attribute.name,
-                kind: languages.CompletionItemKind.Variable,
-                detail: this.parseDetail(attribute.type),
-                insertText: this.parseAttributeInputText(attribute.name, incomplete),
-                preselect: this.attributeIsRequired(attribute),
-                insertTextRules: languages.CompletionItemInsertTextRule.InsertAsSnippet,
-                documentation: this.parseDocumentation(attribute.documentation),
-            }),
+            (attribute: DocumentNode): ICompletion => {
+                let attributeName = attribute.ref ? attribute.ref : attribute.name;
+                return ({
+                    label: attributeName,
+                    kind: languages.CompletionItemKind.Variable,
+                    detail: this.parseDetail(attribute.type),
+                    insertText: this.parseAttributeInputText(attributeName, incomplete),
+                    preselect: this.attributeIsRequired(attribute),
+                    insertTextRules: languages.CompletionItemInsertTextRule.InsertAsSnippet,
+                    documentation: this.parseDocumentation(attribute.documentation),
+                })
+            }
         )
 
     private parseDetail = (detail: string | undefined) => {

--- a/src/XsdParser.ts
+++ b/src/XsdParser.ts
@@ -143,7 +143,7 @@ export default class XsdParser {
         attributeGroups.forEach((attributeGroup: DocumentNode) => {
             attributes = attributes.concat(this.getAttributesFromAttributeGroup(attributeGroup))
         })
-        return attributes   
+        return attributes
     }
 
     private parseElements = (elements: SelectedValue[]): DocumentNode[] =>

--- a/src/XsdParser.ts
+++ b/src/XsdParser.ts
@@ -142,7 +142,7 @@ export default class XsdParser {
             `${this.namespace}:annotation/${this.namespace}:documentation`,
             attribute,
         )
-            .map((documentation: any): string => documentation.firstChild.data)
+            .map((documentation: any): string => documentation.firstChild ? documentation.firstChild.data : '')
             .join('<br/><hr/><br/>')
         return {
             documentation: `${documentationString}<br/>Source: ${this.xsd.path}`,

--- a/src/XsdParser.ts
+++ b/src/XsdParser.ts
@@ -100,8 +100,8 @@ export default class XsdParser {
             return element
         })
 
-    public getAttributesForElement = (elementName: string): DocumentNode[] =>
-        this.parseAttributes(
+    public getAttributesForElement = (elementName: string): DocumentNode[] => {
+        let attributes = this.parseAttributes(
             this.select(
                 `//${this.namespace}:complexType[@name='${this.getElementType(elementName)}']/${
                     this.namespace
@@ -109,6 +109,42 @@ export default class XsdParser {
                 this.xsdDom,
             ),
         )
+        let attributeGroups = this.parseAttributes(
+            this.select(
+                `//${this.namespace}:complexType[@name='${this.getElementType(elementName)}']/${
+                    this.namespace
+                }:attributeGroup`,
+                this.xsdDom,
+            ),
+        )
+        attributeGroups.forEach((attributeGroup: DocumentNode) => {
+            attributes = attributes.concat(this.getAttributesFromAttributeGroup(attributeGroup))
+        })
+        return attributes
+    }
+
+    public getAttributesFromAttributeGroup = (attributeGroup: DocumentNode): DocumentNode[] => {
+        let attributes = this.parseAttributes(
+            this.select(
+                `//${this.namespace}:attributeGroup[@name='${attributeGroup.ref}']/${
+                    this.namespace
+                }:attribute`,
+                this.xsdDom,
+            ),
+        )
+        let attributeGroups = this.parseAttributes(
+            this.select(
+                `//${this.namespace}:attributeGroup[@name='${attributeGroup.ref}']/${
+                    this.namespace
+                }:attributeGroup`,
+                this.xsdDom,
+            ),
+        )
+        attributeGroups.forEach((attributeGroup: DocumentNode) => {
+            attributes = attributes.concat(this.getAttributesFromAttributeGroup(attributeGroup))
+        })
+        return attributes   
+    }
 
     private parseElements = (elements: SelectedValue[]): DocumentNode[] =>
         elements.map(

--- a/src/types.ts
+++ b/src/types.ts
@@ -178,4 +178,5 @@ export interface DocumentNode {
     documentation?: string
     type?: string
     use?: string
+    ref?: string
 }


### PR DESCRIPTION
This update has the following changes.

1. list sub elements of ref type. ref type elements in xsd has no name attribute, because of this the returned collection had only the direct elements.

2. When getting element attributes, it'll take `attributeGroups` also into consideration.